### PR TITLE
Laravel 13 compatibility (Wave 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 DreamFactory MongoDB Service
 
 This is a service library for the DreamFactory platform containing a MongoDB database service and resources.
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,18 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-database": "~1.0",
-    "dreamfactory/df-file":     "~0.8",
-    "jenssegers/mongodb":       "^4.2.0"
+    "php":                      "^8.3",
+    "laravel/helpers":          "^1.8",
+    "dreamfactory/df-database": "~1.4",
+    "dreamfactory/df-file":     "~0.8|~0.9",
+    "mongodb/laravel-mongodb":  "^5.7"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Database/Schema/Schema.php
+++ b/src/Database/Schema/Schema.php
@@ -3,7 +3,7 @@ namespace DreamFactory\Core\MongoDb\Database\Schema;
 
 use DreamFactory\Core\Database\Schema\ColumnSchema;
 use DreamFactory\Core\Database\Schema\TableSchema;
-use Jenssegers\Mongodb\Connection;
+use MongoDB\Laravel\Connection;
 use MongoDB\Model\CollectionInfo;
 use \Illuminate\Support\Arr;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,17 +11,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function register()
     {
-        // Ensure MongoDB package is loaded
-        if (!class_exists('MongoDB\Laravel\MongoDBServiceProvider')) {
-            // Try to load it from vendor
-            $providerPath = base_path('vendor/jenssegers/mongodb/src/MongoDBServiceProvider.php');
-            if (file_exists($providerPath)) {
-                require_once $providerPath;
-            }
-        }
-
-        // Register the MongoDB service provider
-        if (class_exists('MongoDB\Laravel\MongoDBServiceProvider')) {
+        // Register the MongoDB service provider (mongodb/laravel-mongodb ^5.7)
+        if (class_exists('MongoDB\\Laravel\\MongoDBServiceProvider')) {
             $this->app->register(\MongoDB\Laravel\MongoDBServiceProvider::class);
         }
 

--- a/src/Services/MongoDb.php
+++ b/src/Services/MongoDb.php
@@ -8,7 +8,7 @@ use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\MongoDb\Database\Schema\Schema as DatabaseSchema;
 use DreamFactory\Core\MongoDb\Resources\Table;
 use Illuminate\Database\DatabaseManager;
-use Jenssegers\Mongodb\Connection;
+use MongoDB\Laravel\Connection;
 use \Illuminate\Support\Arr;
 
 /**

--- a/tests/MongoDbServiceTest.php
+++ b/tests/MongoDbServiceTest.php
@@ -28,9 +28,9 @@ class MongoDbTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCase
      */
     protected $service = null;
 
-    public function setup()
+    public function setUp(): void
     {
-        parent::setup();
+        parent::setUp();
 
         $options = [];
         $this->service = new MongoDb(
@@ -52,7 +52,7 @@ class MongoDbTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }


### PR DESCRIPTION
## Summary

Wave 2 Laravel 13 upgrade for `df-mongodb`. Brings the package onto the L13.7 dep matrix and replaces the abandoned `jenssegers/mongodb` library with the official MongoDB Inc. fork `mongodb/laravel-mongodb`.

### What changed
- `composer.json`
  - `php ^8.3`, `laravel/framework ^13.7` (require-dev), `phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`, `laravel/helpers ^1.8`.
  - `dreamfactory/df-database ~1.4` (was `~1.0`) — aligns with df-database's L13 floor.
  - `dreamfactory/df-file ~0.8|~0.9` — host shift-173254 ships `~0.9.0`.
  - `jenssegers/mongodb ^4.2` -> `mongodb/laravel-mongodb ^5.7` (5.7 is the lowest 5.x that declares `illuminate/support: ^13.0`; 5.6 caps at L12).
- `src/Database/Schema/Schema.php`, `src/Services/MongoDb.php`
  - `use Jenssegers\Mongodb\Connection;` -> `use MongoDB\Laravel\Connection;`
- `src/ServiceProvider.php`
  - Drop the legacy `vendor/jenssegers/mongodb/...` `require_once` fallback. Register `MongoDB\Laravel\MongoDBServiceProvider` directly (class_exists string-form check kept so the package fails gracefully if the runtime is missing the new lib).
- `tests/MongoDbServiceTest.php`
  - PHPUnit 11 case-sensitive method names: `setup()` -> `setUp(): void`, `tearDown()` -> `tearDown(): void`.

### Tested
- **Stage 1** (isolated install with path-repos for df-core/df-system/df-database/df-file all on `shift/laravel-13`): composer resolves to `laravel/framework 13.7.0` + `mongodb/laravel-mongodb 5.7.1` + `mongodb/mongodb 2.3.0`. 13/13 namespaced classes + 3 helper polyfills load.
- **Stage 2** (host-app `shift-173254` with df-mongodb path-repo, standard strip-list `df-oauth`/`df-mcp-server`/`df-mongo-logs`/`df-git`): `composer install` + `package:discover` succeed cleanly. 20/20 smoke checks pass (df-mongodb classes, `MongoDB\Laravel\*` chain, sibling SPs, helpers).

### Caveats / blockers
- `mongodb/laravel-mongodb ^5.7` requires `ext-mongodb ^1.21|^2`. The container today has `ext-mongodb 1.20.x` — must bump to 1.21+ when L13 ships. Stage 1/2 used `--ignore-platform-req=ext-mongodb` to validate composer resolution.
- Source files outside the two updated `use` lines (`Resources/Table.php`, `Components/GridFsSystem.php`) reference the raw `MongoDB\` driver namespaces (`MongoDB\BSON\*`, `MongoDB\Client`, etc.), which are PECL-driver classes unaffected by the rename.

## Test plan
- [ ] CI green on `shift/laravel-13`.
- [ ] Once `ext-mongodb` is bumped in the container, run the existing test suite (`MongoDbServiceTest`, `GridFsServiceTest`, `MongoDbConfigTest`) against a live MongoDB.
- [ ] Verify `MongoDB\Laravel\MongoDBServiceProvider` registration is idempotent when the host's `config/app.php` also lists it (Laravel's `app->register` deduplicates; no-op).
- [ ] Smoke a basic CRUD round-trip via the DreamFactory REST API once L13 ships, including a GridFS file upload to confirm `Components/GridFsSystem` still resolves.