### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require":     {
     "dreamfactory/df-database": "~1.0",
     "dreamfactory/df-file":     "~0.8",
-    "jenssegers/mongodb":       "^4.2.0"
+    "mongodb/laravel-mongodb":  "^4.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,18 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-database": "~1.0",
-    "dreamfactory/df-file":     "~0.8",
-    "jenssegers/mongodb":       "^4.2.0"
+    "php":                      "^8.3",
+    "laravel/helpers":          "^1.8",
+    "dreamfactory/df-database": "~1.4",
+    "dreamfactory/df-file":     "~0.8|~0.9",
+    "mongodb/laravel-mongodb":  "^5.7"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Database/Schema/Schema.php
+++ b/src/Database/Schema/Schema.php
@@ -3,7 +3,7 @@ namespace DreamFactory\Core\MongoDb\Database\Schema;
 
 use DreamFactory\Core\Database\Schema\ColumnSchema;
 use DreamFactory\Core\Database\Schema\TableSchema;
-use Jenssegers\Mongodb\Connection;
+use MongoDB\Laravel\Connection;
 use MongoDB\Model\CollectionInfo;
 use \Illuminate\Support\Arr;
 

--- a/src/Resources/Table.php
+++ b/src/Resources/Table.php
@@ -30,6 +30,45 @@ use \Illuminate\Support\Arr;
 
 class Table extends BaseNoSqlDbTableResource
 {
+    /**
+     * MongoDB operators that allow server-side JavaScript execution or
+     * are otherwise unsafe in caller-supplied filters. These must never
+     * appear in a filter constructed from request input.
+     */
+    private const FORBIDDEN_FILTER_OPERATORS = [
+        '$where',        // arbitrary JS query expression
+        '$function',     // (4.4+) inline JS aggregation function
+        '$accumulator',  // (4.4+) custom JS accumulator
+        '$expr',         // can be a foothold for $function inside aggregation
+        'mapReduce',     // legacy JS map-reduce
+    ];
+
+    /**
+     * Reject MongoDB filters that contain JavaScript-execution or other
+     * unsafe operators. Recurses into nested arrays so a payload like
+     * {"$or": [{"$where": "..."}, ...]} is also caught.
+     *
+     * @throws BadRequestException
+     */
+    public static function assertSafeMongoFilter(array $filter): void
+    {
+        foreach ($filter as $key => $value) {
+            if (is_string($key)) {
+                $needle = strtolower($key);
+                foreach (self::FORBIDDEN_FILTER_OPERATORS as $op) {
+                    if (strtolower($op) === $needle) {
+                        throw new BadRequestException(
+                            "MongoDB filter contains forbidden operator: {$key}"
+                        );
+                    }
+                }
+            }
+            if (is_array($value)) {
+                self::assertSafeMongoFilter($value);
+            }
+        }
+    }
+
     //*************************************************************************
     //	Constants
     //*************************************************************************
@@ -335,7 +374,12 @@ class Table extends BaseNoSqlDbTableResource
         }
 
         if (is_array($filter)) {
-            // assume client knows correct usage of Mongo query language
+            // Reject filter operators that allow JavaScript execution or
+            // operate as server-side scripts. Without this, a caller could
+            // post a filter like {"$where": "this.password.match(...)"} and
+            // exfiltrate field contents via timing oracle, or use $function
+            // / $accumulator to run arbitrary JS in the MongoDB process.
+            self::assertSafeMongoFilter($filter);
             return static::toMongoObjects($filter);
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,7 +14,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         // Ensure MongoDB package is loaded
         if (!class_exists('MongoDB\Laravel\MongoDBServiceProvider')) {
             // Try to load it from vendor
-            $providerPath = base_path('vendor/jenssegers/mongodb/src/MongoDBServiceProvider.php');
+            $providerPath = base_path('vendor/mongodb/laravel-mongodb/src/MongoDBServiceProvider.php');
             if (file_exists($providerPath)) {
                 require_once $providerPath;
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,17 +11,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function register()
     {
-        // Ensure MongoDB package is loaded
-        if (!class_exists('MongoDB\Laravel\MongoDBServiceProvider')) {
-            // Try to load it from vendor
-            $providerPath = base_path('vendor/jenssegers/mongodb/src/MongoDBServiceProvider.php');
-            if (file_exists($providerPath)) {
-                require_once $providerPath;
-            }
-        }
-
-        // Register the MongoDB service provider
-        if (class_exists('MongoDB\Laravel\MongoDBServiceProvider')) {
+        // Register the MongoDB service provider (mongodb/laravel-mongodb ^5.7)
+        if (class_exists('MongoDB\\Laravel\\MongoDBServiceProvider')) {
             $this->app->register(\MongoDB\Laravel\MongoDBServiceProvider::class);
         }
 

--- a/src/Services/MongoDb.php
+++ b/src/Services/MongoDb.php
@@ -8,7 +8,7 @@ use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\MongoDb\Database\Schema\Schema as DatabaseSchema;
 use DreamFactory\Core\MongoDb\Resources\Table;
 use Illuminate\Database\DatabaseManager;
-use Jenssegers\Mongodb\Connection;
+use MongoDB\Laravel\Connection;
 use \Illuminate\Support\Arr;
 
 /**

--- a/tests/MongoDbServiceTest.php
+++ b/tests/MongoDbServiceTest.php
@@ -28,9 +28,9 @@ class MongoDbTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCase
      */
     protected $service = null;
 
-    public function setup()
+    public function setUp(): void
     {
-        parent::setup();
+        parent::setUp();
 
         $options = [];
         $this->service = new MongoDb(
@@ -52,7 +52,7 @@ class MongoDbTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/Security/MongoFilterAllowlistTest.php
+++ b/tests/Security/MongoFilterAllowlistTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DreamFactory\Core\MongoDb\Tests\Security;
+
+use DreamFactory\Core\Exceptions\BadRequestException;
+use DreamFactory\Core\MongoDb\Resources\Table;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: MongoDB filter operators that execute server-side JavaScript
+ * must be rejected when present in caller-supplied filters.
+ */
+class MongoFilterAllowlistTest extends TestCase
+{
+    /**
+     * @dataProvider unsafeFilterProvider
+     */
+    public function testRejectsUnsafeOperator(array $filter): void
+    {
+        $this->expectException(BadRequestException::class);
+        Table::assertSafeMongoFilter($filter);
+    }
+
+    public static function unsafeFilterProvider(): array
+    {
+        return [
+            'where top-level'     => [['$where' => 'this.password.match(/a/)']],
+            'where capitalized'   => [['$Where' => 'this.x']],
+            'function operator'   => [['$function' => ['body' => '...', 'args' => [], 'lang' => 'js']]],
+            'accumulator op'      => [['field' => ['$accumulator' => []]]],
+            'expr nested'         => [['$expr' => ['$gt' => ['$field', 1]]]],
+            'mapReduce key'       => [['mapReduce' => 'col']],
+            'where nested in $or' => [['$or' => [['name' => 'x'], ['$where' => 'this.password']]]],
+            'where in $and'       => [['$and' => [['$where' => 'this.x']]]],
+        ];
+    }
+
+    /**
+     * @dataProvider safeFilterProvider
+     */
+    public function testAcceptsSafeFilter(array $filter): void
+    {
+        Table::assertSafeMongoFilter($filter);
+        $this->assertTrue(true);
+    }
+
+    public static function safeFilterProvider(): array
+    {
+        return [
+            'simple equality'    => [['name' => 'alice']],
+            'comparison'         => [['age' => ['$gt' => 18]]],
+            'in operator'        => [['status' => ['$in' => ['A', 'B']]]],
+            'nested $and ok'     => [['$and' => [['x' => 1], ['y' => 2]]]],
+            'nested $or ok'      => [['$or' => [['x' => 1], ['y' => 2]]]],
+            'regex'              => [['name' => ['$regex' => '^a']]],
+            'empty'              => [[]],
+        ];
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
